### PR TITLE
Adding GeomLoss to the potential solvers

### DIFF
--- a/objective.py
+++ b/objective.py
@@ -28,7 +28,7 @@ class Objective(BaseObjective):
         # API to pass data.
         self.x, self.a = x, a
         self.y, self.b = y, b
-        self.M = pairwise_distances(self.x, self.y)
+        self.M = pairwise_distances(self.x, self.y) / 2
 
     def compute(self, P):
 

--- a/solvers/geomloss.py
+++ b/solvers/geomloss.py
@@ -4,13 +4,12 @@ from benchopt import BaseSolver, safe_import_context
 # - skipping import to speed up autocompletion in CLI.
 # - getting requirements info when all dependencies are not installed.
 with safe_import_context() as import_ctx:
-    import numpy as np
-
     from geomloss.sinkhorn_divergence import log_weights, sinkhorn_loop
     from geomloss.sinkhorn_samples import cost_routines, softmin_tensorized
     import jax.numpy as jnp
     from ott.geometry import pointcloud
-    from ott.problems.linear import linear_problem, SinkhornOutput
+    from ott.problems.linear import linear_problem
+    from ott.solvers.linear.sinkhorn import SinkhornOutput
     import torch
 
 

--- a/solvers/geomloss.py
+++ b/solvers/geomloss.py
@@ -1,0 +1,87 @@
+from benchopt import BaseSolver, safe_import_context
+
+# Protect the import with `safe_import_context()`. This allows:
+# - skipping import to speed up autocompletion in CLI.
+# - getting requirements info when all dependencies are not installed.
+with safe_import_context() as import_ctx:
+    import numpy as np
+
+    from geomloss.sinkhorn_divergence import log_weights, sinkhorn_loop
+    from geomloss.sinkhorn_samples import cost_routines, softmin_tensorized
+    import torch
+
+
+# The benchmark solvers must be named `Solver` and
+# inherit from `BaseSolver` for `benchopt` to work properly.
+class Solver(BaseSolver):
+
+    # Name to select the solver in the CLI and to display the results.
+    name = 'OTT'
+
+    install_cmd = 'conda'
+    requirements = ['torch', 'pykeops', 'pip:geomloss']
+
+    # List of parameters for the solver. The benchmark will consider
+    # the cross product for each key in the dictionary.
+    parameters = {
+        'reg': [1e-4, 1e-1],
+    }
+
+    def set_objective(self, x, a, y, b):
+        # Convert problem into jax array with int32 for jitted computations.
+        self.x, self.a, self.y, self.b = [
+            torch.from_numpy(t).float()[None] for t in (x, a, y, b)
+        ]
+        # put all tensors on GPU if available
+        if torch.cuda.is_available():
+            self.x, self.a, self.y, self.b = [
+                t.cuda() for t in (self.x, self.a, self.y, self.b)
+            ]
+
+    def run(self, n_iter):
+        x, y, a, b = self.x, self.y, self.a, self.b
+        # Retrieve the batch size B, the numbers of samples N, M
+        # and the size of the ambient space D:
+        B, N, D = x.shape
+        _, M, _ = y.shape
+        p = 2
+        eps = self.reg
+        eps_list = [eps for _ in range(10*n_iter)]
+        cost = None
+
+        # By default, our cost function :math:`C(x_i,y_j)` is a halved,
+        # squared Euclidean distance (p=2) or a simple Euclidean distance (p=1):
+        if cost is None:
+            cost = cost_routines[p]
+
+        # Compute the relevant cost matrices C(x_i, y_j), C(y_j, x_i), etc.
+        # Note that we "detach" the gradients of the "right-hand sides":
+        # this is coherent with the way we compute our gradients
+        # in the `sinkhorn_loop(...)` routine, in the `sinkhorn_divergence.py` file.
+        # Please refer to the comments in this file for more details.
+        C_xy = cost(x, y.detach())  # (B,N,M) torch Tensor
+        C_yx = cost(y, x.detach())  # (B,M,N) torch Tensor
+
+        # N.B.: The "auto-correlation" matrices C(x_i, x_j) and C(y_i, y_j)
+        #       are only used by the "debiased" Sinkhorn algorithm.
+        C_xx = None  # (B,N,N) torch Tensor
+        C_yy = None  # (B,M,M) torch Tensor
+
+        # Use an optimal transport solver to retrieve the dual potentials:
+        f_aa, g_bb, g_ab, f_ba = sinkhorn_loop(
+            softmin_tensorized,
+            log_weights(a),
+            log_weights(b),
+            C_xx,
+            C_yy,
+            C_xy,
+            C_yx,
+            eps_list,
+            None,
+            debias=False,
+        )
+        return f_ba.view_as(a), g_ab.view_as(b)
+
+    def get_result(self):
+        # Return the result from one optimization run.
+        return np.array(self.out)

--- a/solvers/geomloss.py
+++ b/solvers/geomloss.py
@@ -69,14 +69,16 @@ class Solver(BaseSolver):
         cost = None
 
         # By default, our cost function :math:`C(x_i,y_j)` is a halved,
-        # squared Euclidean distance (p=2) or a simple Euclidean distance (p=1):
+        # squared Euclidean distance (p=2) or a simple Euclidean distance
+        # (p=1):
         if cost is None:
             cost = cost_routines[p]
 
         # Compute the relevant cost matrices C(x_i, y_j), C(y_j, x_i), etc.
         # Note that we "detach" the gradients of the "right-hand sides":
         # this is coherent with the way we compute our gradients
-        # in the `sinkhorn_loop(...)` routine, in the `sinkhorn_divergence.py` file.
+        # in the `sinkhorn_loop(...)` routine,
+        # in the `sinkhorn_divergence.py` file.
         # Please refer to the comments in this file for more details.
         C_xy = cost(x, y.detach())  # (B,N,M) torch Tensor
         C_yx = cost(y, x.detach())  # (B,M,N) torch Tensor

--- a/solvers/geomloss.py
+++ b/solvers/geomloss.py
@@ -41,6 +41,7 @@ class Solver(BaseSolver):
         # we skip the solver if use_gpu is True and no GPU is available
         if self.use_gpu and not torch.cuda.is_available():
             return True, "No GPU available"
+        return False, None
 
     def set_objective(self, x, a, y, b):
         # Create a ott problem based on jax to compute the output \

--- a/solvers/geomloss.py
+++ b/solvers/geomloss.py
@@ -1,4 +1,5 @@
 from benchopt import BaseSolver, safe_import_context
+from benchopt.stopping_criterion import SufficientProgressCriterion
 
 # Protect the import with `safe_import_context()`. This allows:
 # - skipping import to speed up autocompletion in CLI.
@@ -30,14 +31,16 @@ class Solver(BaseSolver):
         'reg': [1e-2, 1e-1],
     }
 
+    stopping_criterion = SufficientProgressCriterion(patience=10)
+
     def set_objective(self, x, a, y, b):
         # Convert problem into jax array with int32 for jitted computations.
         x_jax, y_jax, a_jax, b_jax = map(
             lambda x: jnp.array(x), (x, y, a, b)
         )
         self.ot_prob = linear_problem.LinearProblem(
-                pointcloud.PointCloud(x_jax, y_jax), a_jax, b_jax
-            )
+            pointcloud.PointCloud(x_jax, y_jax, epsilon=self.reg,), a_jax, b_jax,
+        )
         self.x, self.a, self.y, self.b = [
             torch.from_numpy(t).float()[None] for t in (x, a, y, b)
         ]

--- a/solvers/geomloss.py
+++ b/solvers/geomloss.py
@@ -38,7 +38,8 @@ class Solver(BaseSolver):
     stopping_criterion = SufficientProgressCriterion(patience=50)
 
     def set_objective(self, x, a, y, b):
-        # Create a ott problem based on jax to compute the output of the solver.
+        # Create a ott problem based on jax to compute the output \
+        # of the solver.
         x_jax, y_jax, a_jax, b_jax = map(
             lambda x: jnp.array(x), (x, y, a, b)
         )
@@ -51,7 +52,10 @@ class Solver(BaseSolver):
 
         # Store the problem in torch to use GeomLoss.
         # Use the GPU when it is available.
-        device = 'cuda' if torch.cuda.is_available() and self.use_gpu else 'cpu'
+        device = (
+            'cuda' if torch.cuda.is_available() and self.use_gpu
+            else 'cpu'
+        )
         self.x, self.a, self.y, self.b = [
             torch.from_numpy(t).float().to(device=device)[None]
             for t in (x, a, y, b)

--- a/solvers/geomloss.py
+++ b/solvers/geomloss.py
@@ -27,7 +27,7 @@ class Solver(BaseSolver):
     # List of parameters for the solver. The benchmark will consider
     # the cross product for each key in the dictionary.
     parameters = {
-        'reg': [1e-4, 1e-1],
+        'reg': [1e-2, 1e-1],
     }
 
     def set_objective(self, x, a, y, b):

--- a/solvers/geomloss.py
+++ b/solvers/geomloss.py
@@ -96,9 +96,11 @@ class Solver(BaseSolver):
 
     def get_result(self):
         # Return the result from one optimization run.
+        f = self.f_ba + log_weights(self.a)
+        g = self.g_ab + log_weights(self.b)
         out = SinkhornOutput(
-            f=jnp.array(self.f_ba.detach().cpu().numpy()[0]),
-            g=jnp.array(self.g_ab.detach().cpu().numpy()[0]),
+            f=jnp.array(f.detach().cpu().numpy()[0]),
+            g=jnp.array(g.detach().cpu().numpy()[0]),
             ot_prob=self.ot_prob,
         )
         return np.array(out.matrix)

--- a/solvers/geomloss.py
+++ b/solvers/geomloss.py
@@ -7,6 +7,7 @@ with safe_import_context() as import_ctx:
     from geomloss.sinkhorn_divergence import log_weights, sinkhorn_loop
     from geomloss.sinkhorn_samples import cost_routines, softmin_tensorized
     import jax.numpy as jnp
+    import numpy as np
     from ott.geometry import pointcloud
     from ott.problems.linear import linear_problem
     from ott.solvers.linear.sinkhorn import SinkhornOutput
@@ -18,7 +19,7 @@ with safe_import_context() as import_ctx:
 class Solver(BaseSolver):
 
     # Name to select the solver in the CLI and to display the results.
-    name = 'OTT'
+    name = 'GeomLoss'
 
     install_cmd = 'conda'
     requirements = ['torch', 'pykeops', 'pip:geomloss']
@@ -56,7 +57,7 @@ class Solver(BaseSolver):
         _, M, _ = y.shape
         p = 2
         eps = self.reg
-        eps_list = [eps for _ in range(10*n_iter)]
+        eps_list = [eps for _ in range(max(10*n_iter, 1))]
         cost = None
 
         # By default, our cost function :math:`C(x_i,y_j)` is a halved,
@@ -100,4 +101,4 @@ class Solver(BaseSolver):
             g=jnp.array(self.g_ab.detach().cpu().numpy()[0]),
             ot_prob=self.ot_prob,
         )
-        return out.matrix
+        return np.array(out.matrix)

--- a/solvers/geomloss.py
+++ b/solvers/geomloss.py
@@ -39,6 +39,8 @@ class Solver(BaseSolver):
             ]
 
     def run(self, n_iter):
+        # content of `sinkhorn_tensorized` from
+        # https://github.com/jeanfeydy/geomloss/blob/main/geomloss/sinkhorn_samples.py
         x, y, a, b = self.x, self.y, self.a, self.b
         # Retrieve the batch size B, the numbers of samples N, M
         # and the size of the ambient space D:
@@ -80,8 +82,13 @@ class Solver(BaseSolver):
             None,
             debias=False,
         )
-        return f_ba.view_as(a), g_ab.view_as(b)
+        self.f_ba = f_ba.view_as(a)
+        self.g_ab = g_ab.view_as(b)
 
     def get_result(self):
         # Return the result from one optimization run.
+        out = SinkhornOutput(
+            f=jax.array(self.f_ba.detach().cpu().numpy()[0]),
+            g=jax.array(self.g_ab.detach().cpu().numpy()[0]),
+        )
         return np.array(self.out)

--- a/solvers/geomloss.py
+++ b/solvers/geomloss.py
@@ -24,7 +24,7 @@ class Solver(BaseSolver):
     name = 'GeomLoss'
 
     install_cmd = 'conda'
-    requirements = ['torch', 'pykeops', 'pip:geomloss']
+    requirements = ['torch', 'pykeops', 'pip:geomloss', 'ott-jax']
 
     # List of parameters for the solver. The benchmark will consider
     # the cross product for each key in the dictionary.

--- a/solvers/ott.py
+++ b/solvers/ott.py
@@ -8,6 +8,7 @@ with safe_import_context() as import_ctx:
 
     import jax
     import jax.numpy as jnp
+    import ott
     from ott.geometry import pointcloud
     from ott.solvers.linear import sinkhorn
     from ott.problems.linear import linear_problem
@@ -38,7 +39,10 @@ class Solver(BaseSolver):
         # Define a jittable function to call the ott solver.
         def _sinkhorn(x, y, a, b, eps, n_iter):
             prob = linear_problem.LinearProblem(
-                pointcloud.PointCloud(x, y, epsilon=eps), a, b
+                pointcloud.PointCloud(
+                    x, y, epsilon=eps,
+                    cost_fn=ott.geometry.costs.SqPNorm(p=2),
+                ), a, b
             )
             out = sinkhorn.Sinkhorn(
                 threshold=0, lse_mode=True, max_iterations=10 * n_iter + 1,

--- a/solvers/ott.py
+++ b/solvers/ott.py
@@ -38,7 +38,7 @@ class Solver(BaseSolver):
         # Define a jittable function to call the ott solver.
         def _sinkhorn(x, y, a, b, eps, n_iter):
             prob = linear_problem.LinearProblem(
-                pointcloud.PointCloud(x, y), a, b
+                pointcloud.PointCloud(x, y, epsilon=eps), a, b
             )
             out = sinkhorn.Sinkhorn(
                 threshold=0, lse_mode=True, max_iterations=10 * n_iter + 1,
@@ -49,7 +49,7 @@ class Solver(BaseSolver):
 
         # Jit the function with static argument n_iter, as it is used to
         # allocate some memory.
-        self.sinkhorn = jax.jit(_sinkhorn, static_argnames='n_iter')
+        self.sinkhorn = jax.jit(_sinkhorn, static_argnames=("eps", "n_iter"))
 
     def pre_run_hook(self, n_iter):
         # Compile the function ahead of the call to not take it
@@ -57,13 +57,13 @@ class Solver(BaseSolver):
         # We cannot do it only once as this compilation is call every time
         # n_iter changes.
         self._sinkhorn_compile = self.sinkhorn.lower(
-            self.x, self.y, self.a, self.b, self.reg, n_iter
+            self.x, self.y, self.a, self.b, float(self.reg), n_iter
         ).compile()
 
     def run(self, n_iter):
         # Run the jitted function compiled ahead-of-time.
         self.out = self._sinkhorn_compile(
-            self.x, self.y, self.a, self.b, self.reg
+            self.x, self.y, self.a, self.b
         )
 
     def get_result(self):

--- a/solvers/ott_lr.py
+++ b/solvers/ott_lr.py
@@ -8,6 +8,7 @@ with safe_import_context() as import_ctx:
 
     import jax
     import jax.numpy as jnp
+    import ott
     from ott.geometry import pointcloud
     from ott.solvers.linear import sinkhorn_lr
     from ott.problems.linear import linear_problem
@@ -38,7 +39,10 @@ class Solver(BaseSolver):
         # Define a jittable function to call the ott solver.
         def _sinkhorn(x, y, a, b, rank, n_iter):
             prob = linear_problem.LinearProblem(
-                pointcloud.PointCloud(x, y), a, b
+                pointcloud.PointCloud(
+                    x, y,
+                    cost_fn=ott.geometry.costs.SqPNorm(p=2),
+                ), a, b
             )
             out = sinkhorn_lr.LRSinkhorn(
                 threshold=0, lse_mode=True, rank=self.rank,

--- a/solvers/pot.py
+++ b/solvers/pot.py
@@ -37,7 +37,7 @@ class Solver(BaseSolver):
         # This is the function that is called to evaluate the solver.
         # It runs the algorithm for a given a number of iterations `n_iter`.
 
-        M = ot.dist(self.x, self.y)
+        M = ot.dist(self.x, self.y) / 2
 
         if self.reg == 0:
             self.P = ot.emd(self.a, self.b, M, numItermax=n_iter)


### PR DESCRIPTION
In order to do so I had to adapt the # content of [`sinkhorn_tensorized`](https://github.com/jeanfeydy/geomloss/blob/main/geomloss/sinkhorn_samples.py).
Indeed, the vanilla `SamplesLoss` does not let one specify the number of steps you want to run or have a fixed regularization (i.e. `eps`) parameter.

Made sure to use a consistent cost function with 1/2 euclidean squared in order to ease comparison between frameworks and have an easy transport matrix construction for geomloss.